### PR TITLE
Mirror of zephyrproject-rtos west#422

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -908,10 +908,11 @@ class Manifest:
                 # neither source_file nor topdir: search the filesystem
                 # for the workspace and use its manifest.path.
                 topdir = util.west_topdir()
+                mpath = _mpath(topdir=topdir)
                 kwargs.update({
                     'topdir': topdir,
-                    'source_file': os.path.join(topdir, _mpath(topdir=topdir),
-                                                _WEST_YML)
+                    'source_file': os.path.join(topdir, mpath, _WEST_YML),
+                    'manifest_path': mpath
                 })
             else:
                 # Just source_file: find topdir starting there.
@@ -919,7 +920,8 @@ class Manifest:
                 kwargs.update({
                     'source_file': source_file,
                     'topdir':
-                    util.west_topdir(start=os.path.dirname(source_file))
+                    util.west_topdir(start=os.path.dirname(source_file)),
+                    'manifest_path': os.path.dirname(source_file)
                 })
         elif source_file is None:
             # Just topdir.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1051,12 +1051,21 @@ def test_as_dict_and_yaml(manifest_repo):
     for p in frozen_expected['manifest']['projects']:
         p['revision'] = fake_sha
 
+    # Manifest.from_file() and Manifest.from_file(topdir=<topdir>) shall
+    # produce result when given topdir is identical to what util.west_topdir()
+    # produces.
     manifest = MF()
+
+    manifest_topdir = MF(topdir=os.path.dirname(manifest_repo))
 
     # We can always call as_dict() and as_yaml(), regardless of what's
     # cloned.
 
     as_dict = manifest.as_dict()
+
+    as_dict_topdir = manifest_topdir.as_dict()
+    assert as_dict == as_dict_topdir
+
     yaml_roundtrip = yaml.safe_load(manifest.as_yaml())
     assert as_dict == content_dict
     assert yaml_roundtrip == content_dict

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1041,7 +1041,7 @@ def test_as_dict_and_yaml(manifest_repo):
                        'path': 'project-two',
                        'clone-depth': 1,
                        'west-commands': 'commands.yml'}],
-                     'self': {}}}
+                     'self': {'path': os.path.basename(manifest_repo)}}}
 
     with open(manifest_repo / 'west.yml', 'w') as f:
         f.write(content_str)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -837,9 +837,8 @@ def test_parse_multiple_manifest_files(manifest_repo):
 
     # Manifest.from_file() should be also usable with another_yml.
     # The project hierarchy in its return value should still be rooted
-    # in the topdir, but the resulting ManifestProject does not have a
-    # path, because it's not set in the file, and we're explicitly not
-    # comparing its path to manifest.path.
+    # in the topdir, but the resulting ManifestProject will have a path
+    # identical to the path of the manifest file.
     #
     # However, the project hierarchy *must* be rooted at topdir.
     manifest = Manifest.from_file(source_file=another_yml)
@@ -847,9 +846,9 @@ def test_parse_multiple_manifest_files(manifest_repo):
     assert manifest.topdir is not None
     assert PurePath(manifest.topdir) == PurePath(topdir)
     mproj = manifest.projects[0]
-    assert mproj.path is None
-    assert mproj.abspath is None
-    assert mproj.posixpath is None
+    assert mproj.path == topdir
+    assert mproj.abspath == topdir
+    assert mproj.posixpath == PurePath(topdir).as_posix()
     p1 = manifest.projects[1]
     assert p1.name == 'another-1'
     assert p1.url == 'another-url-1'


### PR DESCRIPTION
Mirror of zephyrproject-rtos west#422
If `Manifest.from_file(topdir=<topdir>)` is called with topdir then
Manifest is instantiated with topdir, source_file, and manifest_path.

However, if Manifest.from_file() is called without providing
topdir, then Manifest is instantiated with topdir and source_file only.

This causes the path to manifest repo to become None in later calls and
results in: https://github.com/nrfconnect/sdk-zephyr/pull/341

This is now fixed by ensure `manifest_path` is used for instantiating
Manifest class when using Manifest.from_file().

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen<at>nordicsemi.no>
