### PR TITLE
Mirror of zephyrproject-rtos west#418

### DIFF
--- a/src/west/version.py
+++ b/src/west/version.py
@@ -5,7 +5,7 @@
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 # MAINTAINERS:
 #
 # Make sure to update west.manifest.SCHEMA_VERSION if there have been


### PR DESCRIPTION
Mirror of zephyrproject-rtos west#418
The main purpose of this release is to get 877d46c ("app: fix import
error followed by update") out into users' hands. We've only received
one report of this happening in the wild so far, but it's an important
enough bug to cut a point release for.

Test report:

SHA a88d26b928116a8c6999d2d6dbac7f68590f25de is version `0.7.3a1` on PyPI.
Alpha release prepared and uploaded to PyPI as:

```
    git checkout a88d26b928116a8c6999d2d6dbac7f68590f25de
    git clean -ffdx
    WEST_VERSION=0.7.3a1 python3 setup.py sdist bdist_wheel
    twine upload -u zephyr-project dist/*
```

tox passes with `WEST_SKIP_SLOW_TESTS=0` on:

- macOS Catalina 10.15.3 (bare metal, Python 3.8.5, pip 20.2.1)
- Ubuntu 18.04 (docker, Python 3.6.9, pip 9.0.1)
- Ubuntu 20.04 (docker, Python 3.8.2, pip 20.0.2)
- Debian buster (docker, Python 3.7.3, pip 18.1)
- Windows 10 (bare metal, Python 3.8.3, pip 20.2)
- Fedora 31 (docker, Python 3.7.8, pip 19.1.1)
- Arch (bare metal, Python Python 3.8.5, pip 20.2.1)

Zephyr specific testing in MAINTAINERS.rst passes on:

- macOS Catalina (bare metal, see above)
- Windows 10 (bare metal, see above)
- Ubuntu 20.04 (VM on windows 10 machine, Python 3.8.2, pip 20.2.1)


